### PR TITLE
[MASTER] Switch to Generic Global variant

### DIFF
--- a/AndroidProducts.mk
+++ b/AndroidProducts.mk
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PRODUCT_MAKEFILES := $(LOCAL_DIR)/aosp_xqct72.mk
+PRODUCT_MAKEFILES := $(LOCAL_DIR)/aosp_xqct54.mk
 
 COMMON_LUNCH_CHOICES += \
-    aosp_xqct72-eng \
-    aosp_xqct72-userdebug
+    aosp_xqct54-eng \
+    aosp_xqct54-userdebug

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -15,10 +15,10 @@
 include device/sony/nagara/PlatformConfig.mk
 
 TARGET_BOOTLOADER_BOARD_NAME := unknown
-ifneq (,$(filter %xqct72,$(TARGET_PRODUCT)))
-TARGET_BOOTLOADER_BOARD_NAME := XQ-CT72
+ifneq (,$(filter %xqct54,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := XQ-CT54
 else
-TARGET_BOOTLOADER_BOARD_NAME := XQ-CT72
+TARGET_BOOTLOADER_BOARD_NAME := XQ-CT54
 $(warning Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)", using default value: "$(TARGET_BOOTLOADER_BOARD_NAME)")
 endif
 

--- a/aosp_xqct54.mk
+++ b/aosp_xqct54.mk
@@ -25,7 +25,7 @@ $(call inherit-product, device/sony/pdx223/device.mk)
 $(call inherit-product, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base_telephony.mk)
 
-PRODUCT_NAME := aosp_xqct72
+PRODUCT_NAME := aosp_xqct54
 PRODUCT_DEVICE := pdx223
 PRODUCT_MODEL := Xperia 1 IV (AOSP)
 PRODUCT_BRAND := Sony


### PR DESCRIPTION
XQ-CT54 is the variant we should be using
as it is the generic global variant.

Based-on: https://github.com/sonyxperiadev/device-sony-pdx225/commit/03c8d5f49506d1e48c60db7ae6d3760b78ce4ab6

Signed-off-by: Martin Botka <martin.botka@somainline.org>