### PR TITLE
BoardConfig.mk: move ab.fstab_suffix to cmdline

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -27,7 +27,7 @@ PRODUCT_PLATFORM := nagara
 
 # Kernel cmdline
 BOARD_BOOTCONFIG += androidboot.hardware=pdx223
-BOARD_BOOTCONFIG += androidboot.fstab_suffix=pdx223
+BOARD_KERNEL_CMDLINE += androidboot.fstab_suffix=pdx223
 
 # Partition information
 BOARD_FLASH_BLOCK_SIZE := 131072 # (BOARD_KERNEL_PAGESIZE * 64)


### PR DESCRIPTION
It is not legal to overwrite bootconfig variables and this
key is associated with "default" by the bootloader.. yikes!