### PR TITLE
BoardConfig: Suggest 1096x2560 framebuffer-console cmdline

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -29,6 +29,9 @@ PRODUCT_PLATFORM := nagara
 BOARD_BOOTCONFIG += androidboot.hardware=pdx223
 BOARD_KERNEL_CMDLINE += androidboot.fstab_suffix=pdx223
 
+# FB console
+#BOARD_KERNEL_CMDLINE += earlycon=simplefb,0xb8000000,1096,2560
+
 # Partition information
 BOARD_FLASH_BLOCK_SIZE := 131072 # (BOARD_KERNEL_PAGESIZE * 64)
 BOARD_BOOTIMAGE_PARTITION_SIZE := 0x06000000


### PR DESCRIPTION
The commented-out kernel cmdline suggestion in the nagara platform repo is only applicable to 1IV (pdx223) with its larger screen: move it into this pdx223 repo to keep it separated from the 5IV (pdx224) config, which has a different resolution.
