### PR TITLE
BoardConfig: Set `PRODUCT_PLATFORM` before including `KernelConfig.mk`

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Platform
+PRODUCT_PLATFORM := nagara
+
 include device/sony/nagara/PlatformConfig.mk
 
 TARGET_BOOTLOADER_BOARD_NAME := unknown
@@ -21,9 +24,6 @@ else
 TARGET_BOOTLOADER_BOARD_NAME := XQ-CT54
 $(warning Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)", using default value: "$(TARGET_BOOTLOADER_BOARD_NAME)")
 endif
-
-# Platform
-PRODUCT_PLATFORM := nagara
 
 # Kernel cmdline
 BOARD_BOOTCONFIG += androidboot.hardware=pdx223


### PR DESCRIPTION
Our generic kernel config needs to know the platform now that the kernel is only built once for it, instead of being built twice with identical configurations for the two devices (pdx22[34]) making up the Nagara platform.  Set the variable before including `PlatformConfig.mk`, which includes `CommonConfig.mk`, which includes `KernelConfig.mk`.

Theoretically this shared variable should be set in `PlatformConfig.mk` though.

https://github.com/sonyxperiadev/kernel/pull/2561
https://github.com/sonyxperiadev/kernel-sony-msm-5.10-common/pull/5
https://github.com/sonyxperiadev/kernel-defconfig/pull/128
https://github.com/sonyxperiadev/device-sony-pdx224/pull/4