### PR TITLE
Allow build for xqct72 variant

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -20,6 +20,8 @@ include device/sony/nagara/PlatformConfig.mk
 TARGET_BOOTLOADER_BOARD_NAME := unknown
 ifneq (,$(filter %xqct54,$(TARGET_PRODUCT)))
 TARGET_BOOTLOADER_BOARD_NAME := XQ-CT54
+else ifneq (,$(filter %xqct72,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := XQ-CT72
 else
 TARGET_BOOTLOADER_BOARD_NAME := XQ-CT54
 $(warning Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)", using default value: "$(TARGET_BOOTLOADER_BOARD_NAME)")

--- a/aosp_xqct72.mk
+++ b/aosp_xqct72.mk
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PRODUCT_MAKEFILES := $(LOCAL_DIR)/aosp_xqct54.mk \
-    $(LOCAL_DIR)/aosp_xqct72.mk
+$(call inherit-product, device/sony/pdx223/aosp_xqct54.mk)
 
-COMMON_LUNCH_CHOICES += \
-    aosp_xqct54-eng \
-    aosp_xqct54-userdebug \
-    aosp_xqct72-eng \
-    aosp_xqct72-userdebug
-
+PRODUCT_NAME := aosp_xqct72


### PR DESCRIPTION
This patch allows build for XQ-CT72 variant.
I succeeded build and boot for this variant.