### PR TITLE
[android-16] device: Add vendor prefix to USB PID suffix property

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -76,7 +76,7 @@ PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
 PRODUCT_PROPERTY_OVERRIDES := \
     ro.sf.lcd_density=420 \
-    ro.usb.pid_suffix=20d
+    ro.vendor.usb.pid_suffix=20d
 
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/nagara/platform.mk)


### PR DESCRIPTION
The property is vendor-specific and must use a vendor prefix.
The USB Gadget HAL expects the updated property.